### PR TITLE
Add ngrok

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -36,13 +36,22 @@ jobs:
           function randomStringGenerator() {
             tr -dc "a-zA-Z0-9@#$%^&*()_+?><~\`;'" </dev/urandom | head -c 64 ; echo '';
           }
-          echo "GARM_PASSWORD=$(randomStringGenerator)" >> $GITHUB_ENV
-          echo "REPO_WEBHOOK_SECRET=$(randomStringGenerator)" >> $GITHUB_ENV
-          echo "ORG_WEBHOOK_SECRET=$(randomStringGenerator)" >> $GITHUB_ENV
+
+          GARM_PASSWORD=$(randomStringGenerator)
+          REPO_WEBHOOK_SECRET=$(randomStringGenerator)
+          ORG_WEBHOOK_SECRET=$(randomStringGenerator)
+
+          echo "::add-mask::$GARM_PASSWORD" 
+          echo "::add-mask::$REPO_WEBHOOK_SECRET" 
+          echo "::add-mask::$ORG_WEBHOOK_SECRET" 
+
+          echo "GARM_PASSWORD=$GARM_PASSWORD" >> $GITHUB_ENV
+          echo "REPO_WEBHOOK_SECRET=$REPO_WEBHOOK_SECRET" >> $GITHUB_ENV
+          echo "ORG_WEBHOOK_SECRET=$ORG_WEBHOOK_SECRET" >> $GITHUB_ENV
       
       - name: Set up ngrok
         id: ngrok
-        uses: gabriel-samfira/ngrok-tunnel-action@867169320326b49398c565de3b3f0ee75fb1599a
+        uses: gabriel-samfira/ngrok-tunnel-action@v1.1
         with:
           ngrok_authtoken: ${{ secrets.NGROK_AUTH_TOKEN }}
           port: 9997

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -26,23 +26,38 @@ jobs:
         run: make build
 
       - name: Setup GARM
-        run: sudo --preserve-env ./test/integration/scripts/setup-garm.sh
+        run: ./test/integration/scripts/setup-garm.sh
         env:
           GH_OAUTH_TOKEN: ${{ secrets.GH_OAUTH_TOKEN }}
           CREDENTIALS_NAME: test-garm-creds
 
+      - name: Generate secrets
+        run: |
+          function randomStringGenerator() {
+            tr -dc "a-zA-Z0-9@#$%^&*()_+?><~\`;'" </dev/urandom | head -c 64 ; echo '';
+          }
+          echo "GARM_PASSWORD=$(randomStringGenerator)" >> $GITHUB_ENV
+          echo "REPO_WEBHOOK_SECRET=$(randomStringGenerator)" >> $GITHUB_ENV
+          echo "ORG_WEBHOOK_SECRET=$(randomStringGenerator)" >> $GITHUB_ENV
+      
+      - name: Set up ngrok
+        id: ngrok
+        uses: gabriel-samfira/ngrok-tunnel-action@v1.0
+        with:
+          ngrok_authtoken: ${{ secrets.NGROK_AUTH_TOKEN }}
+          port: 9997
+          tunnel_type: http
+          
+
       - name: Run integration tests
         run: go run ./test/integration/e2e.go
         env:
-          GARM_BASE_URL: http://127.0.0.1:9997
+          GARM_BASE_URL: ${{ steps.ngrok.outputs.tunnel-url }}
           GARM_USERNAME: admin
-          GARM_PASSWORD: ${{ secrets.GARM_ADMIN_PASSWORD }}
           GARM_FULLNAME: Local GARM Admin
           GARM_EMAIL: admin@example.com
           GARM_NAME: local_garm
           CREDENTIALS_NAME: test-garm-creds
-          REPO_WEBHOOK_SECRET: ${{ secrets.REPO_WEBHOOK_SECRET }}
-          ORG_WEBHOOK_SECRET: ${{ secrets.ORG_WEBHOOK_SECRET }}
 
       - name: Show GARM logs
         if: always()

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -42,12 +42,11 @@ jobs:
       
       - name: Set up ngrok
         id: ngrok
-        uses: gabriel-samfira/ngrok-tunnel-action@v1.0
+        uses: gabriel-samfira/ngrok-tunnel-action@867169320326b49398c565de3b3f0ee75fb1599a
         with:
           ngrok_authtoken: ${{ secrets.NGROK_AUTH_TOKEN }}
           port: 9997
           tunnel_type: http
-          
 
       - name: Run integration tests
         run: go run ./test/integration/e2e.go

--- a/test/integration/scripts/setup-garm.sh
+++ b/test/integration/scripts/setup-garm.sh
@@ -4,7 +4,7 @@ set -o errexit
 DIR="$(dirname $0)"
 BINARIES_DIR="$PWD/bin"
 CONTRIB_DIR="$PWD/contrib"
-CONFIG_DIR="$PWD/config"
+CONFIG_DIR="$PWD/test/integration/config"
 
 if [[ ! -f $BINARIES_DIR/garm ]] || [[ ! -f $BINARIES_DIR/garm-cli ]]; then
     echo "ERROR: Please build GARM binaries first"

--- a/test/integration/scripts/setup-garm.sh
+++ b/test/integration/scripts/setup-garm.sh
@@ -1,15 +1,10 @@
 #!/usr/bin/env bash
 set -o errexit
 
-if [[ $EUID -ne 0 ]]; then
-    echo "ERROR: Please run $0 script as root"
-    exit 1
-fi
-
 DIR="$(dirname $0)"
-BINARIES_DIR="$DIR/../../../bin"
-CONTRIB_DIR="$DIR/../../../contrib"
-CONFIG_DIR="$DIR/../config"
+BINARIES_DIR="$PWD/bin"
+CONTRIB_DIR="$PWD/contrib"
+CONFIG_DIR="$PWD/config"
 
 if [[ ! -f $BINARIES_DIR/garm ]] || [[ ! -f $BINARIES_DIR/garm-cli ]]; then
     echo "ERROR: Please build GARM binaries first"
@@ -47,17 +42,17 @@ export JWT_AUTH_SECRET="$(generate_secret)"
 export DB_PASSPHRASE="$(generate_secret)"
 
 # Group "adm" is the LXD daemon group as set by the "canonical/setup-lxd" GitHub action.
-useradd --shell /usr/bin/false --system --groups adm --no-create-home garm
+sudo useradd --shell /usr/bin/false --system --groups adm --no-create-home garm
 
-mkdir -p /etc/garm
-cat $CONFIG_DIR/config.toml | envsubst > /etc/garm/config.toml
-chown -R garm:garm /etc/garm
+sudo mkdir -p /etc/garm
+cat $CONFIG_DIR/config.toml | envsubst | sudo tee /etc/garm/config.toml
+sudo chown -R garm:garm /etc/garm
 
-mv $BINARIES_DIR/* /usr/local/bin/
-cp $CONTRIB_DIR/garm.service /etc/systemd/system/garm.service
+sudo mv $BINARIES_DIR/* /usr/local/bin/
+sudo cp $CONTRIB_DIR/garm.service /etc/systemd/system/garm.service
 
-systemctl daemon-reload
-systemctl start garm
+sudo systemctl daemon-reload
+sudo systemctl start garm
 
 wait_open_port 127.0.0.1 9997
 


### PR DESCRIPTION
This change adds ngrok action and changes how the setup script is run. To avoid the need to preserve env when running with sudo, we simply use sudo inside the script wherever needed.

Sudo may filter out environment variables even when preserve env is used.